### PR TITLE
Fix header Markdown in Wiring Reference

### DIFF
--- a/Wiring_reference.md
+++ b/Wiring_reference.md
@@ -310,7 +310,7 @@ disablePower(section)
 | POWER_SERIAL1 |
 | POWER_ALL     |
 
-####Returns
+#### Returns
 `none`
 <br/>
 


### PR DESCRIPTION
GitHub's Markdown interpreter was recently changed to strictly enforce the [GFM spec](https://github.github.com/gfm/), which requires a delimiting space in header Markdown. This has caused some Markdown to no longer display as originally intended.

More information:
https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown
https://github.com/github/markup/issues/1013